### PR TITLE
Update AWS TF stack to use a mix of public and private subnets.

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -14,7 +14,7 @@ For best results, we recommend applying this terraform stack in an empty AWS sub
 
 First, make sure you can access your AWS account with the AWS CLI. You may need to copy credentials into `~/.aws/credentials` and set your `AWS_PROFILE` environment variable.
 
-Next, create a file in this directory (or wherever you plan to run terraform) called `terraform.tfvars`. In this file, you'll define some variables to cofigure your install. This file should have the following entries:
+Next, create a file in this directory (or wherever you plan to run terraform) called `terraform.tfvars`. In this file, you'll define some variables to cofigure your install. This file should have at least the following entries:
 
 ```
 global_environment_name = "<YOUR_UNIQUE_ENVIRONMENT_NAME_HERE>"
@@ -25,6 +25,11 @@ Finally, run the following command to initialize terraform:
 ```
 terraform init
 ```
+
+## Private Installs
+This stack has an option to deploy W&B entirely inside a VPC and expose nothing to the internet. To choose this option, specify `deployment_is_private = true` in your `terraform.tfvars` file. Note that if you choose this option, you will only be able to access your W&B instance from inside your VPC (or via VPN connection).
+
+This stack also contains an option to make the kubernetes API server endpoint private. To choose this option, specify `kubernetes_api_is_private = true` in your `terraform.tfvars` file. If you choose this option, you'll have to run the "Installing W&B in the Cluster" step below with a VPN connection active, since the kubernetes API server endpoint will be private to the VPC. This stack does not provision any VPN resources -- you will have to set up VPN access manually between the two terraform steps described below.
 
 ## Creating the Cluster (and other resources)
 To create the cluster, run the following command:

--- a/terraform/aws/infra/infra.tf
+++ b/terraform/aws/infra/infra.tf
@@ -32,6 +32,11 @@ variable "deployment_is_private" {
   type        = bool
   default     = false
 }
+variable "kubernetes_api_is_private" {
+  description = "If true, the kubernetes API server endpoint will be private."
+  type        = bool
+  default     = false
+}
 
 ##########################################
 # Data
@@ -187,7 +192,7 @@ resource "aws_eks_cluster" "wandb" {
 
   vpc_config {
     endpoint_private_access = true
-    endpoint_public_access  = ! var.deployment_is_private
+    endpoint_public_access  = ! var.kubernetes_api_is_private
     security_group_ids      = [aws_security_group.eks_master.id]
     subnet_ids              = aws_subnet.wandb_private[*].id
   }

--- a/terraform/aws/infra/infra.tf
+++ b/terraform/aws/infra/infra.tf
@@ -27,6 +27,12 @@ variable "db_password" {
   type        = string
 }
 
+variable "deployment_is_private" {
+  description = "If true, the load balancer will be placed in a private subnet, and the kubernetes API server endpoint will be private."
+  type        = bool
+  default     = false
+}
+
 ##########################################
 # Data
 ##########################################
@@ -52,7 +58,7 @@ resource "aws_vpc" "wandb" {
   }
 }
 
-resource "aws_subnet" "wandb" {
+resource "aws_subnet" "wandb_public" {
   count = 2
 
   availability_zone       = data.aws_availability_zones.available.names[count.index]
@@ -61,11 +67,48 @@ resource "aws_subnet" "wandb" {
   map_public_ip_on_launch = true
 
   tags = {
-    "Name"                        = "wandb-${count.index}"
+    "Name"                        = "wandb-public-${count.index}"
     "kubernetes.io/cluster/wandb" = "shared"
   }
 }
 
+resource "aws_subnet" "wandb_private" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = "10.10.${length(aws_subnet.wandb_public) + count.index}.0/24"
+  vpc_id            = aws_vpc.wandb.id
+
+  depends_on = [aws_subnet.wandb_public]
+
+  tags = {
+    "Name"                        = "wandb-private-${count.index}"
+    "kubernetes.io/cluster/wandb" = "shared"
+  }
+}
+
+resource "aws_eip" "wandb" {
+  count = 2
+
+  vpc = true
+
+  tags = {
+    Name = "wandb-eip-${count.index}"
+  }
+}
+
+resource "aws_nat_gateway" "wandb" {
+  count = 2
+
+  allocation_id = aws_eip.wandb[count.index].id
+  subnet_id     = aws_subnet.wandb_public[count.index].id
+
+  depends_on = [aws_internet_gateway.wandb]
+
+  tags = {
+    Name = "wandb-nat-gateway-${count.index}"
+  }
+}
 resource "aws_internet_gateway" "wandb" {
   vpc_id = aws_vpc.wandb.id
 
@@ -74,20 +117,46 @@ resource "aws_internet_gateway" "wandb" {
   }
 }
 
-resource "aws_route_table" "wandb" {
+resource "aws_route_table" "wandb_public" {
   vpc_id = aws_vpc.wandb.id
 
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.wandb.id
   }
+
+  tags = {
+    Name = "wandb-route-table-public"
+  }
 }
 
-resource "aws_route_table_association" "wandb_workers" {
+resource "aws_route_table_association" "wandb_public" {
   count = 2
 
-  subnet_id      = aws_subnet.wandb[count.index].id
-  route_table_id = aws_route_table.wandb.id
+  subnet_id      = aws_subnet.wandb_public[count.index].id
+  route_table_id = aws_route_table.wandb_public.id
+}
+
+resource "aws_route_table" "wandb_private" {
+  count = 2
+
+  vpc_id = aws_vpc.wandb.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.wandb[count.index].id
+  }
+
+  tags = {
+    Name = "wandb-route-table-private-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "wandb_private" {
+  count = 2
+
+  subnet_id      = aws_subnet.wandb_private[count.index].id
+  route_table_id = aws_route_table.wandb_private[count.index].id
 }
 
 ##########################################
@@ -114,11 +183,13 @@ resource "aws_security_group" "eks_master" {
 resource "aws_eks_cluster" "wandb" {
   name     = "wandb"
   role_arn = aws_iam_role.wandb_cluster_role.arn
-  version  = "1.15"
+  version  = "1.18"
 
   vpc_config {
-    security_group_ids = [aws_security_group.eks_master.id]
-    subnet_ids         = aws_subnet.wandb.*.id
+    endpoint_private_access = true
+    endpoint_public_access  = ! var.deployment_is_private
+    security_group_ids      = [aws_security_group.eks_master.id]
+    subnet_ids              = aws_subnet.wandb_private[*].id
   }
 
   depends_on = [
@@ -256,9 +327,9 @@ resource "aws_iam_role_policy_attachment" "wandb_node_sqs_policy" {
 
 resource "aws_eks_node_group" "eks_worker_node_group" {
   cluster_name    = aws_eks_cluster.wandb.name
-  node_group_name = "wandb-node-group"
+  node_group_name = "wandb-eks-node-group"
   node_role_arn   = aws_iam_role.wandb_node_role.arn
-  subnet_ids      = aws_subnet.wandb[*].id
+  subnet_ids      = aws_subnet.wandb_private[*].id
 
   scaling_config {
     desired_size = 1
@@ -271,6 +342,7 @@ resource "aws_eks_node_group" "eks_worker_node_group" {
   # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [
+    aws_eks_cluster.wandb,
     aws_iam_role_policy_attachment.wandb_node_worker_policy,
     aws_iam_role_policy_attachment.wandb_node_cni_policy,
     aws_iam_role_policy_attachment.wandb_node_registry_policy,
@@ -314,10 +386,10 @@ resource "aws_security_group" "wandb_alb" {
 
 resource "aws_lb" "wandb" {
   name               = "wandb-alb"
-  internal           = false
+  internal           = var.deployment_is_private
   load_balancer_type = "application"
   security_groups    = [aws_security_group.wandb_alb.id]
-  subnets            = aws_subnet.wandb.*.id
+  subnets            = var.deployment_is_private ? aws_subnet.wandb_private[*].id : aws_subnet.wandb_public[*].id
 }
 
 output "lb_address" {
@@ -481,7 +553,7 @@ resource "aws_s3_bucket_notification" "file_metadata_sns" {
 
 resource "aws_db_subnet_group" "metadata_subnets" {
   name       = "wandb-db-subnets"
-  subnet_ids = aws_subnet.wandb.*.id
+  subnet_ids = aws_subnet.wandb_private[*].id
 }
 
 resource "aws_rds_cluster" "metadata_cluster" {

--- a/terraform/aws/local.tf
+++ b/terraform/aws/local.tf
@@ -25,12 +25,19 @@ variable "wandb_version" {
   default     = "0.9.30"
 }
 
+variable "deployment_is_private" {
+  description = "If true, the load balancer will be placed in a private subnet, and the kubernetes API server endpoint will be private."
+  type        = bool
+  default     = false
+}
+
 
 module "infra" {
   source = "./infra"
 
   global_environment_name = var.global_environment_name
   db_password             = var.db_password
+  deployment_is_private   = var.deployment_is_private
 }
 
 module "kube" {

--- a/terraform/aws/local.tf
+++ b/terraform/aws/local.tf
@@ -36,15 +36,35 @@ variable "kubernetes_api_is_private" {
   type        = bool
   default     = false
 }
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "public_subnet_cidr_blocks" {
+  description = "CIDR blocks for the public VPC subnets. Should be a list of 2 CIDR blocks."
+  type        = list(string)
+  default     = ["10.10.0.0/24", "10.10.1.0/24"]
+}
+
+variable "private_subnet_cidr_blocks" {
+  description = "CIDR blocks for the private VPC subnets. Should be a list of 2 CIDR blocks."
+  type        = list(string)
+  default     = ["10.10.2.0/24", "10.10.3.0/24"]
+}
 
 
 module "infra" {
   source = "./infra"
 
-  global_environment_name   = var.global_environment_name
-  db_password               = var.db_password
-  deployment_is_private     = var.deployment_is_private
-  kubernetes_api_is_private = var.kubernetes_api_is_private
+  global_environment_name    = var.global_environment_name
+  db_password                = var.db_password
+  deployment_is_private      = var.deployment_is_private
+  kubernetes_api_is_private  = var.kubernetes_api_is_private
+  vpc_cidr_block             = var.vpc_cidr_block
+  public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
+  private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
 }
 
 module "kube" {

--- a/terraform/aws/local.tf
+++ b/terraform/aws/local.tf
@@ -31,13 +31,20 @@ variable "deployment_is_private" {
   default     = false
 }
 
+variable "kubernetes_api_is_private" {
+  description = "If true, the kubernetes API server endpoint will be private."
+  type        = bool
+  default     = false
+}
+
 
 module "infra" {
   source = "./infra"
 
-  global_environment_name = var.global_environment_name
-  db_password             = var.db_password
-  deployment_is_private   = var.deployment_is_private
+  global_environment_name   = var.global_environment_name
+  db_password               = var.db_password
+  deployment_is_private     = var.deployment_is_private
+  kubernetes_api_is_private = var.kubernetes_api_is_private
 }
 
 module "kube" {


### PR DESCRIPTION
Default deployment now defaults to the scheme described in [this article ](https://aws.amazon.com/blogs/containers/de-mystifying-cluster-networking-for-amazon-eks-worker-nodes/) as "Public + Private subnets"