### PR TITLE
remove aws-iam-authenticator dependency

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -7,7 +7,6 @@ This repo contains a terraform stack you can use to deploy your very own W&B Loc
 To use this install guide, you must have the following utilities installed already:
 * [Terraform 0.12.25](https://releases.hashicorp.com/terraform/0.12.25/)
 * [AWS CLI](https://aws.amazon.com/cli/)
-* [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
 
 ## Preparing for Install
 For best results, we recommend applying this terraform stack in an empty AWS subaccount. We also recommend against making custom modifications to this terraform stack (outside of specifying configurable variables) -- we can only guarantee that the default stack in the main branch of this repo is fully functional.

--- a/terraform/aws/infra/infra.tf
+++ b/terraform/aws/infra/infra.tf
@@ -223,6 +223,14 @@ resource "aws_eks_cluster" "wandb" {
   ]
 }
 
+data "aws_eks_cluster_auth" "wandb" {
+  name = "wandb"
+}
+
+output "eks_cluster_token" {
+  value = data.aws_eks_cluster_auth.wandb.token
+}
+
 output "eks_cluster_endpoint" {
   value = aws_eks_cluster.wandb.endpoint
 }
@@ -417,8 +425,8 @@ resource "aws_lb" "wandb" {
   subnets            = var.deployment_is_private ? aws_subnet.wandb_private[*].id : aws_subnet.wandb_public[*].id
 }
 
-output "lb_address" {
-  value = "http://${aws_lb.wandb.dns_name}"
+output "lb_dns_name" {
+  value = aws_lb.wandb.dns_name
 }
 
 resource "aws_lb_target_group" "wandb_tg" {

--- a/terraform/aws/kube/kube.tf
+++ b/terraform/aws/kube/kube.tf
@@ -12,16 +12,17 @@ provider "kubernetes" {
   config_context_auth_info = "aws"
   config_context_cluster   = "kubernetes"
 
-  exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
-    command     = "aws-iam-authenticator"
-    args        = ["token", "-i", "wandb"]
-  }
+  token = var.token
 }
 
 ##########################################
 # Variables
 ##########################################
+
+variable "token" {
+  description = "The token of the kubernetes cluster."
+  type        = string
+}
 
 variable "license" {
   description = "The license string for your local instance."
@@ -194,12 +195,6 @@ resource "local_file" "kubeconfig" {
     users:
     - name: aws
       user:
-        exec:
-          apiVersion: client.authentication.k8s.io/v1alpha1
-          command: aws-iam-authenticator
-          args:
-            - "token"
-            - "-i"
-            - "wandb"
+        token: ${var.token}
 KUBECONFIG
 }

--- a/terraform/aws/local.tf
+++ b/terraform/aws/local.tf
@@ -85,8 +85,9 @@ module "kube" {
   file_storage_bucket_region = module.infra.s3_bucket_region
   file_metadata_queue_name   = module.infra.sqs_queue_name
   database_endpoint          = module.infra.rds_connection_string
+  token                      = module.infra.eks_cluster_token
 }
 
 output "url" {
-  value = module.infra.lb_address
+  value = "http://${module.infra.lb_dns_name}"
 }


### PR DESCRIPTION
Hello, this PR removes the use of `aws-iam-authenticator`. This is useful when deploying the terraform files using [Terraform Cloud](https://www.terraform.io/cloud), where it is not so easy to install custom software such as `aws-iam-authenticator`.

These changes have been tested locally. See:

```
Outputs:

url = http://wandb-alb-2115193926.us-west-2.elb.amazonaws.com
root@ubuntu-s-1vcpu-1gb-amd-nyc3-01:~/local/terraform/aws# snap install kubectl --classic
kubectl 1.21.1 from Canonical✓ installed
root@ubuntu-s-1vcpu-1gb-amd-nyc3-01:~/local/terraform/aws# kubectl --kubeconfig=kubeconfig.yaml get pods
NAME                    READY   STATUS    RESTARTS   AGE
wandb-7566c648d-dg5vt   1/1     Running   0          17h
```