### PR TITLE
wandb version bump for legacy aws and azure

### DIFF
--- a/terraform/aws/local.tf
+++ b/terraform/aws/local.tf
@@ -28,7 +28,7 @@ variable "db_password" {
 variable "wandb_version" {
   description = "The version of wandb to deploy."
   type        = string
-  default     = "0.21.0"
+  default     = "0.22.0"
 }
 
 variable "deployment_is_private" {

--- a/terraform/azure/local.tf
+++ b/terraform/azure/local.tf
@@ -40,7 +40,7 @@ variable "db_password" {
 variable "wandb_version" {
   description = "The version of wandb to deploy."
   type        = string
-  default     = "0.21.0"
+  default     = "0.22.0"
 }
 
 variable "deployment_is_private" {


### PR DESCRIPTION
Updates wandb version to the latest 0.22.0 release.